### PR TITLE
Adds Fastboot compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import('bower_components/perfect-scrollbar/js/perfect-scrollbar.js');
-    app.import('bower_components/perfect-scrollbar/css/perfect-scrollbar.css');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/perfect-scrollbar/js/perfect-scrollbar.js');
+      app.import(app.bowerDirectory + '/perfect-scrollbar/css/perfect-scrollbar.css');
+    }
+
   }
 };


### PR DESCRIPTION
This PR ensures Ember CLI Scrollbar doesn't break [Fastboot](https://github.com/ember-fastboot/ember-cli-fastboot) builds.